### PR TITLE
BP-3429-New-installation-is-showing-SQL-errors-due-to-older-MySQL-version

### DIFF
--- a/buckaroo3.php
+++ b/buckaroo3.php
@@ -234,9 +234,13 @@ class Buckaroo3 extends PaymentModule
             return false;
         }
 
-        $refundSettingsService = $this->get('buckaroo.refund.settings');
-        if ($refundSettingsService) {
-            $refundSettingsService->uninstall();
+        try {
+            $refundSettingsService = $this->get('buckaroo.refund.settings');
+            if ($refundSettingsService) {
+                $refundSettingsService->uninstall();
+            }
+        } catch (\Exception $e) {
+             $this->_errors[] = 'Failed to uninstall buckaroo.refund.settings: ' . $e->getMessage();
         }
 
         return parent::uninstall();

--- a/src/Entity/BkConfiguration.php
+++ b/src/Entity/BkConfiguration.php
@@ -62,13 +62,6 @@ class BkConfiguration
      */
     private $createdAt;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="updated_at", type="datetime")
-     */
-    private $updatedAt;
-
     public function getId(): int
     {
         return $this->id;
@@ -107,15 +100,5 @@ class BkConfiguration
     public function setCreatedAt(\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
-    }
-
-    public function getUpdatedAt(): \DateTime
-    {
-        return $this->updatedAt;
-    }
-
-    public function setUpdatedAt(\DateTime $updatedAt): void
-    {
-        $this->updatedAt = $updatedAt;
     }
 }

--- a/src/Entity/BkOrdering.php
+++ b/src/Entity/BkOrdering.php
@@ -62,13 +62,6 @@ class BkOrdering
      */
     private $createdAt;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="updated_at", type="datetime")
-     */
-    private $updatedAt;
-
     public function getId(): int
     {
         return $this->id;
@@ -107,15 +100,5 @@ class BkOrdering
     public function setCreatedAt(\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
-    }
-
-    public function getUpdatedAt(): \DateTime
-    {
-        return $this->updatedAt;
-    }
-
-    public function setUpdatedAt(\DateTime $updatedAt): void
-    {
-        $this->updatedAt = $updatedAt;
     }
 }

--- a/src/Entity/BkPaymentMethods.php
+++ b/src/Entity/BkPaymentMethods.php
@@ -83,13 +83,6 @@ class BkPaymentMethods
      */
     private $createdAt;
 
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="updated_at", type="datetime")
-     */
-    private $updatedAt;
-
     public function getId(): int
     {
         return $this->id;
@@ -158,15 +151,5 @@ class BkPaymentMethods
     public function setCreatedAt(\DateTime $createdAt): void
     {
         $this->createdAt = $createdAt;
-    }
-
-    public function getUpdatedAt(): \DateTime
-    {
-        return $this->updatedAt;
-    }
-
-    public function setUpdatedAt(\DateTime $updatedAt): void
-    {
-        $this->updatedAt = $updatedAt;
     }
 }

--- a/src/Install/DatabaseTableInstaller.php
+++ b/src/Install/DatabaseTableInstaller.php
@@ -1,49 +1,49 @@
 <?php
-/**
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * It is available through the world-wide-web at this URL:
- * http://opensource.org/licenses/afl-3.0.php
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this file
- *
- *  @author    Buckaroo.nl <plugins@buckaroo.nl>
- *  @copyright Copyright (c) Buckaroo B.V.
- *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- */
+    /**
+     * NOTICE OF LICENSE
+     *
+     * This source file is subject to the Academic Free License (AFL 3.0)
+     * It is available through the world-wide-web at this URL:
+     * http://opensource.org/licenses/afl-3.0.php
+     *
+     * DISCLAIMER
+     *
+     * Do not edit or add to this file if you wish to upgrade this file
+     *
+     * @author    Buckaroo.nl <plugins@buckaroo.nl>
+     * @copyright Copyright (c) Buckaroo B.V.
+     * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+     */
 
-namespace Buckaroo\PrestaShop\Src\Install;
+    namespace Buckaroo\PrestaShop\Src\Install;
 
-if (!defined('_PS_VERSION_')) {
-    exit;
-}
-
-final class DatabaseTableInstaller implements InstallerInterface
-{
-    public function install()
-    {
-        $commands = $this->getCommands();
-
-        foreach ($commands as $query) {
-            if (!\Db::getInstance()->execute($query)) {
-                return false;
-            }
-        }
-
-        return true;
+    if (!defined('_PS_VERSION_')) {
+        exit;
     }
 
-    /**
-     * @return array
-     */
-    private function getCommands()
+    final class DatabaseTableInstaller implements InstallerInterface
     {
-        $sql = [];
+        public function install()
+        {
+            $commands = $this->getCommands();
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_refund_request` (
+            foreach ($commands as $query) {
+                if (!\Db::getInstance()->execute($query)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /**
+         * @return array
+         */
+        private function getCommands()
+        {
+            $sql = [];
+
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_refund_request` (
 				`id`              INT(11) AUTO_INCREMENT PRIMARY KEY,
 				`order_id`        INT(11) NOT NULL,
 				`amount`          DOUBLE PRECISION NOT NULL,
@@ -52,84 +52,76 @@ final class DatabaseTableInstaller implements InstallerInterface
 				`payment_key`     VARCHAR(255) NOT NULL,
 				`payload`         LONGTEXT NOT NULL,
                 `data`            LONGTEXT NOT NULL,
-				`created_at`      DATETIME NOT NULL,
+                `created_at`      TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
 				INDEX order_id_index (order_id),
                 INDEX key_index (refund_key)
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_payment_methods` (
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_payment_methods` (
 				`id`                INT(11) AUTO_INCREMENT PRIMARY KEY,
 				`name`              VARCHAR(255) NOT NULL,
 				`label`             VARCHAR(255) NOT NULL,
 				`icon`              VARCHAR(255) NOT NULL,
 				`template`          VARCHAR(255) NOT NULL,
 				`is_payment_method` INT(11) NOT NULL,
-                `created_at`        DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                `updated_at`        DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP,
+                `created_at`        TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
                 INDEX(`name`)
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'buckaroo_fee` (
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'buckaroo_fee` (
 				`id`              INT(11) AUTO_INCREMENT PRIMARY KEY,
 				`reference`       TEXT NOT NULL,
 				`id_cart`         TEXT NOT NULL,
 				`buckaroo_fee`    FLOAT,
 				`currency`        TEXT NOT NULL,
-				`created_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                `updated_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
+                `created_at`      TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_configuration` (
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_configuration` (
 				`id`              INT(11) AUTO_INCREMENT PRIMARY KEY,
 				`configurable_id` INT(11) NOT NULL,
 				`value`           TEXT NOT NULL,
-				`created_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                `updated_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
+                `created_at`      TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_ordering` (
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_ordering` (
 				`id`              INT(11) AUTO_INCREMENT PRIMARY KEY,
 				`country_id`      INT(11),
 				`value`           TEXT NOT NULL,
-				`created_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                `updated_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
+                `created_at`      TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_creditcards` (
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_creditcards` (
 				`id`              INT(11) AUTO_INCREMENT PRIMARY KEY,
 				`icon`            VARCHAR(255) NOT NULL,
 				`name`            VARCHAR(255) NOT NULL,
 				`service_code`    VARCHAR(255) NOT NULL,
-                `created_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                `updated_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
+                `created_at`      TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_giftcards` (
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_giftcards` (
 				`id`              INT(11) AUTO_INCREMENT PRIMARY KEY,
 				`code`            VARCHAR(255) NOT NULL,
 				`name`            VARCHAR(255) NOT NULL,
 				`logo`            VARCHAR(255) NOT NULL,
-				`created_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                `updated_at`      DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
+                `created_at`      TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_customer_idin` (
-				`id`                        INT(11) AUTO_INCREMENT PRIMARY KEY,
-				`customer_id`                INT(11) NOT NULL,
-				`buckaroo_idin_consumerbin`  VARCHAR(255) NULL,
-				`buckaroo_idin_iseighteenorolder` VARCHAR(255) NULL,
-				`created_at`                 DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                `updated_at`                 DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_customer_idin` (
+				`id`                                INT(11) AUTO_INCREMENT PRIMARY KEY,
+				`customer_id`                       INT(11) NOT NULL,
+				`buckaroo_idin_consumerbin`         VARCHAR(255) NULL,
+				`buckaroo_idin_iseighteenorolder`   VARCHAR(255) NULL,
+                `created_at`                        TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_product_idin` (
+            $sql[] = 'CREATE TABLE IF NOT EXISTS `' . _DB_PREFIX_ . 'bk_product_idin` (
 				`id`               INT(11) AUTO_INCREMENT PRIMARY KEY,
 				`product_id`       INT(11) NOT NULL,
 				`buckaroo_idin`    TINYINT(1) UNSIGNED DEFAULT 0,
-				`created_at`       DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                `updated_at`       DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL ON UPDATE CURRENT_TIMESTAMP
+                `created_at`       TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
 			) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = ' . _MYSQL_ENGINE_;
 
-        return $sql;
+            return $sql;
+        }
     }
-}

--- a/src/Repository/OrderingRepository.php
+++ b/src/Repository/OrderingRepository.php
@@ -92,7 +92,6 @@ class OrderingRepository extends EntityRepository
             $ordering = new BkOrdering();
             $ordering->setCountryId($countryId);
             $ordering->setCreatedAt(new \DateTime());
-            $ordering->setUpdatedAt(new \DateTime());
         }
 
         $ordering->setValue($value);
@@ -180,7 +179,6 @@ class OrderingRepository extends EntityRepository
         $ordering->setCountryId($countryId);
         $ordering->setValue(json_encode($paymentMethodIds));
         $ordering->setCreatedAt(new \DateTime());
-        $ordering->setUpdatedAt(new \DateTime());
 
         $this->_em->persist($ordering);
         $this->_em->flush();
@@ -206,7 +204,6 @@ class OrderingRepository extends EntityRepository
             $paymentMethodIds[] = $paymentMethodId;
             $ordering->setValue(json_encode($paymentMethodIds));
             $ordering->setCreatedAt(new \DateTime());
-            $ordering->setUpdatedAt(new \DateTime());
 
             $this->_em->persist($ordering);
             $this->_em->flush();


### PR DESCRIPTION
changed DATETIME to TIMESTAMP,removed updated_at, and put buckaroo.refund.settings inside try catch, because when plugin fails to be installed properly the service does not exist then uninstall will fail, so the client is left with a plugin that cant be uninstalled but also don`t work