### PR TITLE
BP-4271-Missing-ConsumerEmail-parameter-when-using-Trustly-payment-method

### DIFF
--- a/library/checkout/trustlycheckout.php
+++ b/library/checkout/trustlycheckout.php
@@ -43,12 +43,25 @@ class TrustlyCheckout extends Checkout
      *
      * @return array
      */
-    protected function getCustomer()
+    protected function getCustomer(): array
     {
+        // 1. Make sure we really have a Customer object if the cart is linked
+        if ((!isset($this->customer) || !$this->customer->id) && $this->context->cart->id_customer) {
+            $this->customer = new \Customer((int) $this->context->cart->id_customer);
+        }
+
+        // 2. Derive the e‑mail (customer first, cookie second)
+        $email = '';
+        if (isset($this->customer->email) && \Validate::isEmail($this->customer->email)) {
+            $email = $this->customer->email;
+        } elseif (!empty($this->context->cookie->email) && \Validate::isEmail($this->context->cookie->email)) {
+            $email = $this->context->cookie->email;
+        }
+
         return [
             'firstName' => $this->invoice_address->firstname,
-            'lastName' => $this->invoice_address->lastname,
-            'email' => !empty($this->customer->email) ? $this->customer->email : '',
+            'lastName'  => $this->invoice_address->lastname,
+            'email'     => $email,
         ];
     }
 


### PR DESCRIPTION
add: derive consumer email from customer object or cookie in Trustly payment method