### PR TITLE
BP-5214-Billink-payment-fails-when-order-total-ends-in-certain-cent-values-PrestaShop

### DIFF
--- a/api/paymentmethods/paymentmethod.php
+++ b/api/paymentmethods/paymentmethod.php
@@ -20,6 +20,7 @@ require_once dirname(__FILE__) . '/responsefactory.php';
 require_once _PS_ROOT_DIR_ . '/modules/buckaroo3/vendor/autoload.php';
 use Buckaroo\BuckarooClient;
 use Buckaroo\PrestaShop\Classes\Config;
+use PrestaShop\Decimal\DecimalNumber;
 
 if (!defined('_PS_VERSION_')) {
     exit;
@@ -112,12 +113,13 @@ abstract class PaymentMethod extends BuckarooAbstract
     {
         $refund_amount = Tools::getValue('refund_amount') ? Tools::getValue('refund_amount') : $this->amountCredit;
         if (in_array($this->type, ['afterpay', 'billink'])) {
+            $refundAmountDecimal = new DecimalNumber((string) $refund_amount);
             $this->data['articles'] = [[
                 'refundType' => 'Return',
                 'identifier' => 1,
                 'description' => 'Refund',
                 'quantity' => 1,
-                'price' => round($refund_amount, 2),
+                'price' => $refundAmountDecimal->toPrecision(2),
                 'vatPercentage' => 0,
             ]];
         }

--- a/library/checkout/checkout.php
+++ b/library/checkout/checkout.php
@@ -361,10 +361,12 @@ abstract class Checkout
             return [];
         }
 
+        $buckarooFeeTaxIncl = new DecimalNumber((string) $buckarooFee['buckaroo_fee_tax_incl']);
+
         return [
             'identifier' => '0',
             'quantity' => '1',
-            'price' => round($buckarooFee['buckaroo_fee_tax_incl'], 2),
+            'price' => $buckarooFeeTaxIncl->toPrecision(2),
             'vatPercentage' => '0',
             'description' => 'buckaroo_fee',
         ];
@@ -374,10 +376,12 @@ abstract class Checkout
     {
         $articles = [];
         foreach ($this->products as $item) {
+            $productPrice = new DecimalNumber((string) $item['price_wt']);
+
             $article = [
                 'identifier' => $item['id_product'],
                 'quantity' => $item['quantity'],
-                'price' => round($item['price_wt'], 2),
+                'price' => $productPrice->toPrecision(2),
                 'vatPercentage' => $item['rate'],
                 'description' => $item['name'],
             ];

--- a/library/checkout/in3checkout.php
+++ b/library/checkout/in3checkout.php
@@ -14,6 +14,9 @@
  *  @copyright Copyright (c) Buckaroo B.V.
  *  @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+use PrestaShop\Decimal\DecimalNumber;
+
 include_once _PS_MODULE_DIR_ . 'buckaroo3/library/checkout/checkout.php';
 
 if (!defined('_PS_VERSION_')) {
@@ -96,60 +99,70 @@ class In3Checkout extends Checkout
      */
     public function getArticles()
     {
-        $total = 0;
+        $total = new DecimalNumber('0');
         $products = [];
         foreach ($this->products as $item) {
+            $itemPrice = new DecimalNumber((string) $item['price_wt']);
+            $itemPricePrecise = $itemPrice->toPrecision(2);
+            
             $products[] = [
                 'description' => $item['name'],
                 'identifier' => $item['id_product'],
                 'quantity' => $item['quantity'],
-                'price' => round($item['price_wt'], 2),
+                'price' => $itemPricePrecise,
                 'vatPercentage' => $item['rate'],
             ];
 
-            $total += round($item['price_wt'] * $item['quantity'], 2);
+            $itemTotal = $itemPrice->times(new DecimalNumber((string) $item['quantity']));
+            $total = $total->plus($itemTotal);
         }
 
         $wrapping = $this->cart->getOrderTotal(true, CartCore::ONLY_WRAPPING);
         if ($wrapping > 0) {
+            $wrappingPrice = new DecimalNumber((string) $wrapping);
             $products[] = [
                 'description' => 'Wrapping',
                 'identifier' => 'WRAP',
                 'quantity' => 1,
-                'price' => round($wrapping, 2),
+                'price' => $wrappingPrice->toPrecision(2),
             ];
-            $total += round($wrapping, 2);
+            $total = $total->plus($wrappingPrice);
         }
 
         $discounts = $this->cart->getOrderTotal(true, CartCore::ONLY_DISCOUNTS);
         if ($discounts > 0) {
+            $discountsPrice = new DecimalNumber((string) $discounts);
             $products[] = [
                 'description' => 'Discounts',
                 'identifier' => 'DISC',
                 'quantity' => 1,
-                'price' => -round($discounts, 2),
+                'price' => $discountsPrice->times(new DecimalNumber('-1'))->toPrecision(2),
             ];
-            $total -= round($discounts, 2);
+            $total = $total->minus($discountsPrice);
         }
 
         $shipping = $this->cart->getOrderTotal(true, CartCore::ONLY_SHIPPING);
         if ($shipping > 0) {
+            $shippingPrice = new DecimalNumber((string) $shipping);
             $products[] = [
                 'description' => 'Shipping',
                 'identifier' => 'SHIP',
                 'quantity' => 1,
-                'price' => round($shipping, 2),
+                'price' => $shippingPrice->toPrecision(2),
             ];
-            $total += round($shipping, 2);
+            $total = $total->plus($shippingPrice);
         }
 
-        $difference = round($this->payment_request->amountDebit - $total, 2);
-        if (abs($difference) >= 0.01) {
+        $amountDebit = new DecimalNumber((string) $this->payment_request->amountDebit);
+        $difference = $amountDebit->minus($total);
+        $differencePrecise = $difference->toPrecision(2);
+        
+        if (abs((float) $differencePrecise) >= 0.01) {
             $products[] = [
                 'description' => 'Other fee/discount',
                 'identifier' => 'OFees',
                 'quantity' => 1,
-                'price' => $difference,
+                'price' => $differencePrecise,
             ];
         }
 

--- a/library/checkout/in3oldcheckout.php
+++ b/library/checkout/in3oldcheckout.php
@@ -14,6 +14,9 @@
  * @copyright Copyright (c) Buckaroo B.V.
  * @license   http://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  */
+
+use PrestaShop\Decimal\DecimalNumber;
+
 include_once _PS_MODULE_DIR_ . 'buckaroo3/library/checkout/checkout.php';
 
 if (!defined('_PS_VERSION_')) {
@@ -156,59 +159,69 @@ class In3OldCheckout extends Checkout
      */
     public function getArticles()
     {
-        $total = 0;
+        $total = new DecimalNumber('0');
         $products = [];
         foreach ($this->products as $item) {
+            $itemPrice = new DecimalNumber((string) $item['price_wt']);
+            $itemPricePrecise = $itemPrice->toPrecision(2);
+            
             $products[] = [
                 'description' => $item['name'],
                 'identifier' => $item['id_product'],
                 'quantity' => $item['quantity'],
-                'price' => round($item['price_wt'], 2),
+                'price' => $itemPricePrecise,
             ];
 
-            $total += round($item['price_wt'] * $item['quantity'], 2);
+            $itemTotal = $itemPrice->times(new DecimalNumber((string) $item['quantity']));
+            $total = $total->plus($itemTotal);
         }
 
         $wrapping = $this->cart->getOrderTotal(true, CartCore::ONLY_WRAPPING);
         if ($wrapping > 0) {
+            $wrappingPrice = new DecimalNumber((string) $wrapping);
             $products[] = [
                 'description' => 'Wrapping',
                 'identifier' => 'WRAP',
                 'quantity' => 1,
-                'price' => round($wrapping, 2),
+                'price' => $wrappingPrice->toPrecision(2),
             ];
-            $total += round($wrapping, 2);
+            $total = $total->plus($wrappingPrice);
         }
 
         $discounts = $this->cart->getOrderTotal(true, CartCore::ONLY_DISCOUNTS);
         if ($discounts > 0) {
+            $discountsPrice = new DecimalNumber((string) $discounts);
             $products[] = [
                 'description' => 'Discounts',
                 'identifier' => 'DISC',
                 'quantity' => 1,
-                'price' => -round($discounts, 2),
+                'price' => $discountsPrice->times(new DecimalNumber('-1'))->toPrecision(2),
             ];
-            $total -= round($discounts, 2);
+            $total = $total->minus($discountsPrice);
         }
 
         $shipping = $this->cart->getOrderTotal(true, CartCore::ONLY_SHIPPING);
         if ($shipping > 0) {
+            $shippingPrice = new DecimalNumber((string) $shipping);
             $products[] = [
                 'description' => 'Shipping',
                 'identifier' => 'SHIP',
                 'quantity' => 1,
-                'price' => round($shipping, 2),
+                'price' => $shippingPrice->toPrecision(2),
             ];
-            $total += round($shipping, 2);
+            $total = $total->plus($shippingPrice);
         }
 
-        $difference = round($this->payment_request->amountDebit - $total, 2);
-        if (abs($difference) >= 0.01) {
+        $amountDebit = new DecimalNumber((string) $this->payment_request->amountDebit);
+        $difference = $amountDebit->minus($total);
+        $differencePrecise = $difference->toPrecision(2);
+        
+        if (abs((float) $differencePrecise) >= 0.01) {
             $products[] = [
                 'description' => 'Other fee/discount',
                 'identifier' => 'OFees',
                 'quantity' => 1,
-                'price' => $difference,
+                'price' => $differencePrecise,
             ];
         }
 


### PR DESCRIPTION
fix: replace rounding with DecimalNumber for precise price calculations